### PR TITLE
Update to structure of xval

### DIFF
--- a/docs/ml/automl/ug/index.md
+++ b/docs/ml/automl/ug/index.md
@@ -17,7 +17,7 @@ The top-level functions in the repository are:
 
 `.automl.new`
 
-: Using a previously fit model and set of instructions derived from `.automl.run`, return predicted values for new tabular data.
+: Using a previously fit model along with the date and time from a previous execution of `.automl.run`, return predicted values for new tabular data.
 
 Both of these functions are modifiable by a user to suit specific use cases and have been designed where possible to cover a wide range of functional options and to be extensible to a users needs. Details regarding all available modifications which can be made are outlined in the [advanced section](options.md).
 
@@ -46,6 +46,7 @@ The default setup saves the following items from an individual run:
 2. A saved report indicating the procedure taken and scores achieved.
 3. A saved binary encoded dictionary denoting, the procedure to be taken for reproducing results, running on new data and outlining all important information relating to a run.
 4. Results from each step of the pipeline published to console.
+5. On application NLP techniques a word2vec model is saved outlining the text to numerical mapping for a specific run.
 
 The following shows the execution of the function `.automl.run` in a regression task for a non-time series application. Data and implementation code is provided for other problem types however for brevity, output is displayed in full for one example only.
 
@@ -118,10 +119,13 @@ Saving down model parameters to /outputs/2020.07.20/run_12.38.51.152/config/
 q)bin_target:asc 100?0b
 q)multi_target:desc 100?3
 q)fresh_data:([]5000?100?0p;asc 5000?1f;5000?1f;desc 5000?10f;5000?0b)
+q)nlp_data:([]100?1f;asc 100?("Testing the application of nlp";"With different characters"))
 // FRESH regression example
 q).automl.run[fresh_data;reg_tgt;`fresh;`reg;::]
 // non-time series/FRESH binary classification example
 q).automl.run[tab;bin_target;`normal;`class;::]
+// NLP binary classification example
+q).automl.run[nlp_data;bin_target;`nlp;`class;::]
 ```
 
 
@@ -140,16 +144,16 @@ Where
 returns the target predictions for new data based on a previously fitted model and workflow.
 
 !!!Note
-	In the below example the date and time are related to a previous run and taken from the return of `.automl.new` the below examples should be run based on your run date and time.
+	In the below example the date and time are related to a previous run and taken from the return of `.automl.new` the below examples should be run based on a users own run date and time.
 
 ```q
 // New dataset
 q)new_tab:([]asc 10?0t;10?1f;desc 10?0b;10?1f;asc 10?1f)
 // string date/time input
-q).automl.new[new_tab;2020.01.02;"11.21.47.763"]
+q).automl.new[new_tab;"2020.01.02";"11.21.47.763"]
 0.1404663 0.255114 0.255114 0.2683779 0.2773197 0.487862 0.6659926 0.8547356 ..
 // q date/time input
-q).automl.new[new_tab;"2020.01.02";11:21:47.763]
+q).automl.new[new_tab;2020.01.02;11:21:47.763]
 0.1953181 0.449196 0.6708352 0.5842918 0.230593 0.4713597 0.1953181 0.0576498..
 ```
 

--- a/docs/ml/automl/ug/options.md
+++ b/docs/ml/automl/ug/options.md
@@ -11,7 +11,7 @@ keywords: machine learning, ml, automated, processing, cross validation, grid se
 :fontawesome-brands-github:
 [KxSystems/automl](https://github.com/kxsystems/automl)
 
-The other sections of the AutoML documentation describe the default behavior of the platform, where `(::)` is passed in as the final parameter to `.automl.run`. This section will focus on how this final parameter can be modified to apply changes to the default behavior. The two methods to complete this are by inputting
+The other sections of the AutoML documentation describe the default behavior of the platform, where `(::)` is passed in as the final parameter to `.automl.run`. This section will focus on how this final parameter can be modified to apply changes to the default behavior. The two methods to complete this based on modifiying the final parameter with
 
 1. q dictionary outlining the changes to default behavior that are to be made
 2. The path to a flat file containing human-readable updates to the parameter set.
@@ -95,7 +95,7 @@ _Grid search procedure_
 
 In each case, the default grid search procedure being implemented is a shuffled 5-fold cross validation. This can be augmented by a user for different use cases, for example in the case of applying grid search to time series data.
 
-The input for this parameter is a mixed list containing the grid-search function name as a symbol and the number of folds to split the data into or the percentage of data in each fold.
+The input for this parameter is a mixed list containing the grid-search function name as a symbol and the number of folds to split the data into or the percentage of data in each fold depending on the procedure undertaken.
 
 For simplicity of implementation, a user should where possible use the functions within the `.ml.gs` namespace for this task.
 
@@ -132,7 +132,7 @@ q).automl.run[tab;tgt;`normal;`reg;enlist[`hld]!enlist tst]
 
 _Type of hyperparameter search to perform_
 
-By default, grid search is applied to the best model found for a given dataset. Random or Sobol-random methods are also available within AutoML and can be applied by changing the hp parameter.
+By default, an exhaustive grid search is applied to the best model found for a given dataset. Random or Sobol-random methods are also available within AutoML and can be applied by changing the hp parameter.
 
 ```q
 q)tab:([]100?1f;asc 100?1f;100?1f;100?1f;100?1f)
@@ -147,7 +147,7 @@ q).automl.run[tab;tgt;`normal;`reg;enlist[`hp]!enlist`sobol]
 
 _Random search procedure_
 
-Assuming `hp` has been changed to `random` or `sobol`, shuffled 5-fold cross validation will be implemented by default. This can be augmented by a user for different use cases, for example in the case of applying random/sobol search to time series data.
+Assuming `hp` has been changed to `random` or `sobol`, shuffled 5-fold cross validation will be implemented by default. This can be modified by a user for different use cases, for example in the case a user wishes to apply random/sobol search to time series data.
 
 The input for this parameter is a mixed list containing the random-search function name as a symbol and the number of folds to split the data into or the percentage of data in each fold.
 
@@ -288,7 +288,7 @@ q).automl.run[tab;tgt;`normal;`reg;enlist[`sz]!enlist size]
 
 _Number of random/Sobol-random hyperparameters to generate_
 
-For the random and Sobol-random hyperparameter methods, a specific number of hyperparameter sets are generated for a given hyperparameter space. 
+For the random and Sobol-random hyperparameter methods, a user specified number of hyperparameter sets are generated for a given hyperparameter space. 
 
 For sobol, the number of trials must equal 2^n, while for random, any number of distinct sets can be generated.
 
@@ -310,7 +310,7 @@ q).automl.run[tab;tgt;`normal;`reg;`hp`trials!(`sobol;n)]
 
 _Word2Vec method used for NLP models_
 
-When applying word2vec vectorization to text, the skip-gram(1) or Continuous-Bag-of-Words(0) method can be applied. By default this value is 0.
+When applying word2vec embedding to text, the Continuous-Bag-of-Words(0) or skip-gram(1) methods can be applied. The default algorithm used is Continuous-Bag-of-Words.
 
 ```q
 q)3#tab
@@ -321,7 +321,7 @@ comment                                                                      ..
 "What a good film! Made Men is a great action movie with lots of twists and t..
 q)tgt:count[tab]?0b
 q)sg:1
-q).automl.run[tab;tgt;`normal;`reg;enlist[`w2v]!enlist sg;
+q).automl.run[tab;tgt;`normal;`reg;enlist[`w2v]!enlist sg]
 
 
 ### `tts`

--- a/docs/ml/automl/ug/preproc.md
+++ b/docs/ml/automl/ug/preproc.md
@@ -127,12 +127,12 @@ Given the automated nature of the machine-learning pipeline, it is important to 
 The following lists show the restricted types for each problem type. In each case these types are not handled gracefully within the feature extraction workflow and thus are omitted
 
 ```txt
-Normal Feature Extraction        FRESH Feature Extraction           NLP Feature Extraction
-  - guid                           - guid                                  - guid
-  - byte                           - byte                                  - byte
-  - list                           - list                                  - list
-  - character                      - character			 
-                                   - time/date types		
+Normal Feature Extraction    FRESH Feature Extraction    NLP Feature Extraction
+  - guid                       - guid                      - guid
+  - byte                       - byte                      - byte
+  - list                       - list                      - list
+  - character                  - character			 
+                               - time/date types		
 ```
 
 The following example shows a truncated output from a normal feature-creation procedure where columns containing byte objects and lists are removed.
@@ -162,7 +162,7 @@ Given the requirement for a one-to-one mapping between the rows output after fea
 
 problem type | description
 :------------|:-----------
-FRESH        | The number of unique configurations of aggregate columns must equal the number of targets
+FRESH        | The number of unique combinations of aggregate columns must equal the number of targets
 Normal       | The number of rows in the input table must equal the number of target values
 NLP          | The number of rows in the input table must equal the number of target values
 
@@ -232,10 +232,18 @@ x          x2
 
 ## Null and infinity replacement
 
-Both null values and infinities are removed from the data due to the inability of machine-learning models in both sklearn and keras to handle this form of data. In the case of `+/-0w`, the values are replaced by the minimum/maximum value of the column, while `0n`'s are replaced by the median value of the column. In cases where nulls are present, an additional column is added denoting the location of the null prior to filling of the dataset, thus encoding the null location in the case that this is an important signal for prediction.
+Both null values and infinities are removed from the data due to the inability of machine-learning models in both sklearn and keras to handle this form of data. In the case of `+/-0w`, the values are replaced by the minimum/maximum value of the column, while `0n`'s are replaced by the median value of the column in order to limit changes to the data distribution. 
+
+In any cases where nulls are present, an additional column is added denoting the location of the null prior to filling of the dataset, thus encoding the null location in the case that this is an important signal for prediction.
 
 ```q
 q)show data:([](3?1f),0n;(3?1f),-0w;4?1f)
+x         x1        x2       
+-----------------------------
+0.5347096 0.1780839 0.3927524
+0.7111716 0.3017723 0.5170911
+0.411597  0.785033  0.5159796
+          -0w       0.4066642
 q).automl.prep.i.nullencode[.ml.infreplace data;med]
 x         x1        x2         x_null
 -------------------------------------

--- a/docs/ml/automl/ug/proc.md
+++ b/docs/ml/automl/ug/proc.md
@@ -12,12 +12,12 @@ keywords: machine learning, ml, automated, processing, cross validation, grid se
 :fontawesome-brands-github:
 [KxSystems/automl](https://github.com/kxsystems/automl)
 
-The procedures outlined below describe the steps required to prepare extracted features for training a model, perform cross validation to determine the most generalizable model and optimize the best model using grid search. These steps follow on from the [data preprocessing methods](preproc.md).
+The procedures outlined below describe the steps required to prepare extracted features for training a model, perform cross validation to determine the most generalizable model and optimize this model using grid search. These steps follow on from the [data preprocessing methods](preproc.md).
 
 The following are the procedures completed when the default system configuration is deployed:
 
 1. Feature extraction is performed using FRESH, normal or NLP feature extraction methods.
-2. Significance tests are applied to extracted features to determine those most relevant for model training.
+2. Feature significance tests are applied to extracted features in order to determine those features most relevant for model training.
 3. Data is split into training, validation and testing sets.
 4. Cross-validation procedures are performed on a selection of models.
 5. Models are scored using a predefined performance metric, based on the problem type (classification/regression), with the best model selected and scored on the validation set.
@@ -26,7 +26,7 @@ The following are the procedures completed when the default system configuration
 
 ## Feature extraction
 
-Feature extraction is the process of building derived or aggregate features from a dataset in order to provide a more suitable or useful input for machine learning algorithms. Within the automated machine learning framework, there are currently 3 types of feature extraction available, FRESH, normal and NLP feature extraction.
+Feature extraction is the process of building derived or aggregate features from a dataset in order to provide the most useful inputs for a machine learning algorithms. Within the automated machine learning framework, there are currently 3 types of feature extraction available, FRESH, normal and NLP feature extraction.
 
 
 ### FRESH
@@ -65,8 +65,51 @@ q)count 1_cols freshfeats
 
     When running `.automl.run` for FRESH data, by default the first column of the dataset is defined as the identifying (ID) column. 
 
-    See instructions on [how to amend this](options.md)
+    See instructions on [how to modify this](options.md)
 
+
+### Natural Language Processing
+
+NLP feature extraction within AutoML makes use of the Kx [NLP library](../nlp/index.md) in addition to the python `gensim` library for data preprocessing. The following are the steps applied independently to all columns containing text data.
+
+1. Using `.nlp.findRegex` retrieve information surrounding the occurrances of various expressions, for example references to urls, money, the presence of phone numbers etc.
+2. Apply named entity recognition to detect references to products, individuals, references to art etc.
+3. Apply sentiment analysis to the dataset to extract information about the positive/negative/neutral and compound nature of the text.
+4. Apply the function `.nlp.newParser` to extract stop words, tokens and any references to numbers. Using this data calculate the percentage of a sentence that are numeric values, stop words or a particular part of speech.
+5. Using the corpus tokens extracted in 4, use the python library `gensim` to create a word2vec encoding of the dataset such that we have a numerical representation of the 'meaning' of a sentence.
+
+If any other non text based columns are present, normal feature extraction is applied to those remaining columns in order to ensure no relevant information is ignored.
+
+Below is an example of NLP feature extraction being applied to a dataset containing strictly text data.
+
+```q
+q)5#tb
+comment                                                                      ..
+-----------------------------------------------------------------------------..
+"If you like plot turns, this is your movie. It is impossible at any moment t..
+"It's a real challenge to make a movie about a baby being devoured by wild ca..
+"What a good film! Made Men is a great action movie with lots of twists and t..
+"This is a movie that is bad in every imaginable way. Sure we like to know wh..
+"There is something special about the Austrian movies not only by Seidl, but ..
+// no. of features before feature extraction
+p)count cols tb
+1
+// Define dictionary to be passed to nlp feature creation
+q)dict:enlist[`seed]!enlist 1234
+// apply nlp feature creation
+q)show nlpfeat:.automl.prep.nlpcreate[tb;dict;0b]`preptab
+ADJ        ADP        ADV        AUX        CCONJ      DET       INTJ        ..
+-----------------------------------------------------------------------------..
+0.1037736  0.04716981 0.0754717  0.0754717  0.02830189 0.1509434 0           ..
+0.07643312 0.1210191  0.02547771 0.06369427 0.06369427 0.1719745 0.006369427 ..
+0.06153846 0.09230769 0.01538462 0.07692308 0.04615385 0.1384615 0           ..
+0.1515152  0.05050505 0.06060606 0.1212121  0.02020202 0.1111111 0.02020202  ..
+0.09195402 0.1310345  0.05747126 0.05747126 0.04137931 0.1632184 0           ..
+0.07211538 0.08173077 0.09615385 0.07692308 0.0625     0.1442308 0           ..
+// no. of features after feature extraction
+q)count cols nlpfeat
+346
+```
 
 ### Normal
 
@@ -101,41 +144,6 @@ q)count normfeat
 8
 ```
 
-### NLP
-
-Using the [NLP library](../nlp/index.md), columns containing text are parsed using `nlp.newParser` to extract features such as stop words , tokens and part-of-speech attributes, along with applying named entity recognition tagging, regular expression searching and sentiment analysis to the text data. The text is then vectorized using a `Word2Vec` model and concatenated with the created features, transforming it an appropriate format for input to a machine learning model. If any other non textual columns are present, normal feature extraction is also applied to those remaining columns.
-
-Below is an example of NLP feature extraction being applied to a dataset containing strictly text.
-
-```q
-q)5#tb
-comment                                                                      ..
------------------------------------------------------------------------------..
-"If you like plot turns, this is your movie. It is impossible at any moment t..
-"It's a real challenge to make a movie about a baby being devoured by wild ca..
-"What a good film! Made Men is a great action movie with lots of twists and t..
-"This is a movie that is bad in every imaginable way. Sure we like to know wh..
-"There is something special about the Austrian movies not only by Seidl, but ..
-// no. of features before feature extraction
-p)count cols tb
-1
-// Define dictionary to be passed to nlp feature creation
-q)dict:enlist[`seed]!enlist 1234
-// apply nlp feature creation
-q)show nlpfeat:.automl.prep.nlpcreate[tb;dict;0b]`preptab
-ADJ        ADP        ADV        AUX        CCONJ      DET       INTJ        ..
------------------------------------------------------------------------------..
-0.1037736  0.04716981 0.0754717  0.0754717  0.02830189 0.1509434 0           ..
-0.07643312 0.1210191  0.02547771 0.06369427 0.06369427 0.1719745 0.006369427 ..
-0.06153846 0.09230769 0.01538462 0.07692308 0.04615385 0.1384615 0           ..
-0.1515152  0.05050505 0.06060606 0.1212121  0.02020202 0.1111111 0.02020202  ..
-0.09195402 0.1310345  0.05747126 0.05747126 0.04137931 0.1632184 0           ..
-0.07211538 0.08173077 0.09615385 0.07692308 0.0625     0.1442308 0           ..
-// no. of features after feature extraction
-q)count cols nlpfeat
-346
-```
-
 The early-stage releases of this repository limit the feature extraction procedures that are performed by default on the tabular data for a number of reasons.
 
 1.  The naïve application of many relevant feature-extraction procedures (truncated singular-value decomposition/bulk transforms) while potentially informative can expand the memory usage and computation time beyond an acceptable level.
@@ -143,6 +151,7 @@ The early-stage releases of this repository limit the feature extraction procedu
 2. Procedures being applied in one field of use may not be relevant in another field. As such the framework is provided to allow a user to complete feature extractions which are domain-specific if required, rather than assuming procedures to be applied are ubiquitous in all cases.
 
 Over time the system will be updated to perform tasks in a way which is cognizant of the above limitations and where general frameworks can be assummed to be informative.
+
 
 
 ## Feature selection

--- a/docs/ml/toolkit/xval.md
+++ b/docs/ml/toolkit/xval.md
@@ -41,9 +41,7 @@ keywords: time-series, cross validation, grid search, random search, Sobol seque
 :fontawesome-brands-github:
 [KxSystems/ml/xval](https://github.com/kxsystems/ml/tree/master/xval/)
 
-The `.ml.xv`, `.ml.gs` and `.ml.rs` namespaces contain functions related to cross validation, grid search, random search and sobol-random search algorithms (more information on [Sobol sequences](https://en.wikipedia.org/wiki/Sobol_sequence)). These algorithms test how robust or stable a model is to changes in the volume of data or the specific subsets of data used for validation.
-
-For grid search, users must specify values for a number of hyperparameters, where a model will be build using every possible combination. In the case of random and sobol, a user only needs to specify the type of hyperparameter search space, along with the lower and upper bounds and the number of hyperparameter sets to generate. These sets are then randomly chosen within the given hyperparameter space using either pseudo-random or sobol-random numbers.
+The `.ml.xv`, `.ml.gs` and `.ml.rs` namespaces contain functions related to cross validation, grid search, random/sobol-random search algorithms respectively. These algorithms are used in machine learning to test how robust or stable a model is to changes in the volume of data or to the specific subsets of data used for model generation.
 
 Within the following examples, `.ml.xv.fitscore` is used extensively to fit models and return the score achieved on validation/test data. This function can be replaced by a user-defined alternative for tailored applications, e.g. a function to fit on training data and predict outputs for new data.
 
@@ -54,11 +52,13 @@ As of toolkit version 0.1.3, the distribution of cross-validation functions is i
   	Interactive notebook implementations of a large number of the functions outlined here are available within :fontawesome-brands-github: [KxSystems/mlnotebooks](https://github.com/KxSystems/mlnotebooks)
     
 
-## Grid Search Functions
+## Grid Search
 
-### Grid Search Hyperparameter Dictionary
+The most common method of perfoming hyperparameter optimization in machine learning is through the use of a grid search. Grid search is an exhaustive searching method across all possible combinations of a hyperparameters provided by a user.
 
-For grid search functions provided in the toolkit, users must provide a dictionary containing hyperparameter names and all the possible values they wish to search. An example is provided below.
+#### Grid Search Hyperparameter Dictionary
+
+When applying the grid search functionality provided within the toolkit, a user must provide a dictionary mapping the names of all the hyperparameters to be searched with the possible values to be considered for the hyperparameter. The following example shows a set of valid hyperparameter dictionaries for an `sklearn` AdaBoostRegressor and `DecisionTreeClassifier`
 
 ```q
 / grid search hyperparameter dictionary for an AdaBoostRegressor
@@ -68,7 +68,7 @@ q)p:enlist[`max_depth]!enlist(::;1;2;3;4;5)
 ```
 
 
-## `.ml.gs.kfshuff`
+### `.ml.gs.kfshuff`
 
 _Cross-validated parameter grid search applied to data with shuffled split indices_
 
@@ -81,10 +81,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#Grid-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#grid-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted grid search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -110,7 +110,7 @@ q).ml.gs.kfshuff[5;1;x;yr;.ml.xv.fitscore rf;pr;.2]
 ```
 
 
-## `.ml.gs.kfsplit`
+### `.ml.gs.kfsplit`
 
 _Cross-validated parameter grid search applied to data with ascending split indices_
 
@@ -123,10 +123,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#Grid-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#grid-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted grid search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -160,7 +160,7 @@ q).ml.gs.kfsplit[10;1;x;yc;.ml.xv.fitscore cf;pc;-.1]
 ```
 
 
-## `.ml.gs.kfstrat`
+### `.ml.gs.kfstrat`
 
 _Cross-validated parameter grid search applied to data with an equi-distributions of targets per fold_
 
@@ -173,10 +173,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#Grid-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#grid-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted grid search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -204,7 +204,7 @@ q).ml.gs.kfstrat[4;1;x;yc;.ml.xv.fitscore cf;pc;.2]
 ```
 
 
-## `.ml.gs.mcsplit`
+### `.ml.gs.mcsplit`
 
 _Cross-validated parameter grid search applied to randomly shuffled data and validated on a percentage holdout set_
 
@@ -217,10 +217,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#Grid-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#grid-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted grid search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -246,7 +246,7 @@ q).ml.gs.mcsplit[0.1;3;x;yr;.ml.xv.fitscore rf;pr;.2]
 ```
 
 
-## `.ml.gs.pcsplit`
+### `.ml.gs.pcsplit`
 
 _Cross-validated parameter grid search applied to percentage split dataset_
 
@@ -259,10 +259,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#Grid-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#grid-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted grid search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -293,7 +293,7 @@ This form of cross validation is also known as _repeated random sub-sampling val
 [Repeated random sub-sampling validation](https://en.wikipedia.org/wiki/Cross-validation_(statistics)#Repeated_random_sub-sampling_validation)
 
 
-## `.ml.gs.tschain`
+### `.ml.gs.tschain`
 
 _Cross-validated parameter grid search applied to chain forward time-series sets_
 
@@ -306,10 +306,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#Grid-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#grid-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted grid search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -343,7 +343,7 @@ This works as shown in the following image:
 The data is split into equi-sized bins with increasing amounts of the data incorporated into the testing set at each step. This avoids testing a model on historical information which would be counter-productive for time-series forecasting. It also allows users to test the robustness of the model when passed increasing volumes of data.
 
 
-## `.ml.gs.tsrolls`
+### `.ml.gs.tsrolls`
 
 _Cross-validated parameter grid search applied to roll forward time-series sets_
 
@@ -356,10 +356,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#Grid-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Grid Search Hyperparameter Dictionary](#grid-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted grid search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -392,39 +392,56 @@ This works as shown in the following image:
 
 Successive equi-sized bins are taken as training and validation sets at each step. This avoids testing a model on historical information which would be counter-productive for time-series forecasting.
 
-## Random Search Functions
+## Random Search
 
-### Random Search Hyperparameter Dictionary
+Random and quasi-random search methods replace the need exhaustive searching across a hyperparameter space used by [grid-search](#grid-search) by selecting combinations of hyperparameters randomly. This random selection can take place across a discrete space as would be the case if choosing randomly from a list of possible values or over a continuous space bounded based on user input. 
+
+Such methods commonly outperform grid search both with respect to finding the optimal parameters in particular in cases where a small number of parameters disproportionately affect the performance of the machine learning algorithm. This library contains two different implementations following the ethos of random search namely
+
+1. Random search
+	
+	The completely random selection of hyperparameters across a defined continuous or discreet search space. 
+
+2. Quasi-random sobol sequence search
+	
+	The selection of hyperparameters across a user defined continuous or discreet space using a quasi-random selection method based on Sobol sequences. This method ensures that the hyperparameters searched encompass a more even representation of the hyperparameter space than is the case in purely random or grid search methods. More information can be found [here](https://en.wikipedia.org/wiki/Sobol_sequence)
+
+
+
+#### Random Search Hyperparameter Dictionary
 
 The random and sobol searching methods follow the same syntax as grid search, with the exception of the `p` parameter. In order to perfom these two searching methods extra information is needed, where the parameter dictionary must have the format:
 
 -   `typ` is the type of random search to perform as a symbol - `random` or `sobol`
 -   `random_state` is the seed to apply during cross validation. If a null character, `(::)`, is passed the default seed, `42`, will be applied.
--   `n` is the number of hyperparameter sets to produce. **Note**: for sobol this number must equal $2^n$, e.g. $4$, $8$, $16$, etc.
+-   `n` is the number of hyperparameter sets to produce. 
+	
+	* **Note**: for sobol this number must equal $2^n$, e.g. $4$, $8$, $16$, etc.
+
 -   `p` is a dictionary of hyperparameters to be searched which must have the following forms:
 
-    Numerical:
-        
-    ```
-    enlist[`hyperparam_name]!enlist(space_type;lower_bound;upper_bound;hp_type)
-    ``` 
+	* **Numerical:**
+		
+		```
+		enlist[`hyperparam_name]!enlist(space_type;lower_bound;upper_bound;hp_type)
+		``` 
+		
+		where `space_type` is `uniform` or `loguniform`, `lower_upper` and `upper_bound` are the limits of the hyperparameter space and `hp_typ` is the type to cast the hyperparameters to.
 
-    where `space_type` is `uniform` or `loguniform`, `lower_upper` and `upper_bound` are the limits of the hyperparameter space and `hp_typ` is the type to cast the hyperparameters to.
+	* **Symbol:**
 
-    Symbol: 
+		```
+		enlist[`hyperparam_name]!enlist(`symbol;symbols_to_search)
+		``` 
+		
+		where `symbol` is given as the type followed by the list of possible symbol values.
 
-    ```
-    enlist[`hyperparam_name]!enlist(`symbol;symbols_to_search)
-    ``` 
-
-    where `symbol` is given as the type followed by the list of possible symbol values.
-
-    Boolean: 
-
-    ```
-    enlist[`hyperparam_name]!enlist`boolean
-    ```
-
+	* **Boolean:**
+		
+		```
+		enlist[`hyperparam_name]!enlist`boolean
+		```
+		
 A practical example is provided below.
         
 ```q
@@ -442,7 +459,7 @@ q)prms:`average`l1_ratio`alpha!(`boolean;(`uniform;0;1;"f");(`loguniform;-5;2;"f
 q)ps:`typ`random_state`n`p!(typ;random_state;n;p)
 ```
         
-## `.ml.rs.kfshuff`
+### `.ml.rs.kfshuff`
 
 _Cross-validated parameter random search applied to data with shuffled split indices_
 
@@ -455,10 +472,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#Random-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#random-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted random or sobol search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -490,7 +507,7 @@ q).ml.rs.kfshuff[5;1;x;yc;.ml.xv.fitscore cf;pr;.2]
 ```
 
 
-## `.ml.rs.kfsplit`
+### `.ml.rs.kfsplit`
 
 _Cross-validated parameter random search applied to data with ascending split indices_
 
@@ -503,10 +520,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#Random-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#random-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted random or sobol search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -547,7 +564,7 @@ q).ml.rs.kfsplit[10;1;x;yc;.ml.xv.fitscore cf;ps;-.1]
 ```
 
 
-## `.ml.rs.kfstrat`
+### `.ml.rs.kfstrat`
 
 _Cross-validated parameter random search applied to data with an equi-distributions of targets per fold_
 
@@ -560,10 +577,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#Random-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#random-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted random or sobol search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -596,7 +613,7 @@ q).ml.rs.kfstrat[4;1;x;yc;.ml.xv.fitscore cf;pr;.2]
 ```
 
 
-## `.ml.rs.mcsplit`
+### `.ml.rs.mcsplit`
 
 _Cross-validated parameter random search applied to randomly shuffled data and validated on a percentage holdout set_
 
@@ -609,10 +626,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#Random-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#random-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted random or sobol search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -647,7 +664,7 @@ q).ml.rs.mcsplit[0.1;3;x;yr;.ml.xv.fitscore dt;ps;.2]
 ```
 
 
-## `.ml.rs.pcsplit`
+### `.ml.rs.pcsplit`
 
 _Cross-validated parameter random search applied to percentage split dataset_
 
@@ -660,10 +677,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#Random-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#random-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted random or sobol search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -701,7 +718,7 @@ This form of cross validation is also known as _repeated random sub-sampling val
 [Repeated random sub-sampling validation](https://en.wikipedia.org/wiki/Cross-validation_(statistics)#Repeated_random_sub-sampling_validation)
 
 
-## `.ml.rs.tschain`
+### `.ml.rs.tschain`
 
 _Cross-validated parameter random search applied to chain forward time-series sets_
 
@@ -714,10 +731,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#Random-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#random-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted random or sobol search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -758,7 +775,7 @@ This works as shown in the following image:
 The data is split into equi-sized bins with increasing amounts of the data incorporated into the testing set at each step. This avoids testing a model on historical information which would be counter-productive for time-series forecasting. It also allows users to test the robustness of the model when passed increasing volumes of data.
 
 
-## `.ml.rs.tsrolls`
+### `.ml.rs.tsrolls`
 
 _Cross-validated parameter random search applied to roll forward time-series sets_
 
@@ -771,10 +788,10 @@ Where
 -   `x` is a matrix of features
 -   `y` is a vector of targets
 -   `f` is a function that takes parameters and data as input and returns a score
--   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#Random-Search-Hyperparameter-Dictionary)
+-   `p` is a dictionary of hyperparameters to be searched - see section [Random Search Hyperparameter Dictionary](#random-search-hyperparameter-dictionary)
 -   `h` is a float value denoting the size of the holdout set used in a fitted random or sobol search, where the best model is fit to the holdout set. If 0 the function will return scores for each fold for the given hyperparameters. If negative the data will be shuffled prior to designation of the holdout set.
 
-returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <=1`.
+returns the scores for hyperparameter sets on each of the `k` folds for all values of `h` and additionally returns the best hyperparameters and score on the holdout set for `0 < h <= 1`.
 
 ```q
 q)m:10000
@@ -813,9 +830,12 @@ This works as shown in the following image:
 
 Successive equi-sized bins are taken as training and validation sets at each step. This avoids testing a model on historical information which would be counter-productive for time-series forecasting.
 
-## Cross Validation Functions
 
-## `.ml.xv.kfshuff`
+## Cross Validation
+
+Cross-validation is a technique used to gain a statistical understanding of how well a machine learning model generalizes to independent datasets. This is used to limit overfitting and selection bias, especially when dealing with small datasets.
+
+### `.ml.xv.kfshuff`
 
 _K-Fold cross validation for randomized non-repeating indices_
 
@@ -844,7 +864,7 @@ q).ml.xv.kfshuff[k;n;x;yr;mdlfn]
 ```
 
 
-## `.ml.xv.kfsplit`
+### `.ml.xv.kfsplit`
 
 _K-Fold cross-validation for ascending indices split into K-folds_
 
@@ -873,7 +893,7 @@ q).ml.xv.kfsplit[k;n;x;yr;mdlfn]
 ```
 
 
-## `.ml.xv.kfstrat`
+### `.ml.xv.kfstrat`
 
 _Stratified K-Fold cross-validation with an approximately equal distribution of classes per fold_
 
@@ -904,7 +924,7 @@ q).ml.xv.kfsplit[k;n;x;yc;mdlfn]
 This is used extensively where the distribution of classes in the data is unbalanced.
 
 
-## `.ml.xv.mcsplit`
+### `.ml.xv.mcsplit`
 
 _Monte-Carlo cross validation using randomized non-repeating indices_
 
@@ -938,7 +958,7 @@ This form of cross validation is also known as _repeated random sub-sampling val
 [Repeated random sub-sampling validation](https://en.wikipedia.org/wiki/Cross-validation_(statistics)#Repeated_random_sub-sampling_validation "Wikipedia")
 
 
-## `.ml.xv.pcsplit`
+### `.ml.xv.pcsplit`
 
 _Percentage split cross-validation procedure_
 
@@ -967,7 +987,7 @@ q).ml.xv.pcsplit[p;n;x;yr;mdlfn]
 ```
 
 
-## `.ml.xv.tschain`
+### `.ml.xv.tschain`
 
 _Chain-forward cross-validation procedure_
 
@@ -1002,7 +1022,7 @@ This works as shown in the following image.
 The data is split into equi-sized bins with increasing amounts of the data incorporated in the testing set at each step. This avoids testing a model on historical information which would be counter-productive for time-series forecasting. It also allows users to test the robustness of the model with data of increasing volumes.
 
 
-## `.ml.xv.tsrolls`
+### `.ml.xv.tsrolls`
 
 _Roll-forward cross-validation procedure_
 


### PR DESCRIPTION
* Update to hyperlinks to move around the documentation 
* Improvement to structure of dictionary explanation
* Changes to header `#`'s to show precedence more clearly i.e. functions for `gs` exist under the grid search section not at the same level
* More explicit definitions of the section contents, what is grid search, what is random search etc