### PR TITLE
Updates to clustering docs and minor changes to graph doc

### DIFF
--- a/docs/ml/toolkit/clustering/algos.md
+++ b/docs/ml/toolkit/clustering/algos.md
@@ -141,10 +141,10 @@ Syntax: `.ml.clust.cure.fit[data;df;n;c]`
 
 Where
 
--   `data` represents the points being analyzed in matrix format, where each column is an individual data point.
--   `df`  is the distance function as a symbol: `e2dist` `edist` `mdist` – see [Distance Metrics](#distance-metrics).
--   `n` is the number of representative points.
--   `c` is the compression ratio.
+-   `data` represents the points being analyzed in matrix format, where each column is an individual data point
+-   `df`  is the distance function as a symbol: ``` `e2dist`edist`mdist ``` – see [Distance Metrics](#distance-metrics)
+-   `n` is the number of representative points
+-   `c` is the compression ratio
 
 returns a dictionary with data, input variables and a dendrogram table. The dendrogram table describes the order in which clusters are joined, and the distance between the clusters as they are joined.
 
@@ -341,7 +341,7 @@ Syntax: `.ml.clust.dbscan.fit[data;df;minpts;eps]`
 Where
 
 -   `data` represents the points being analyzed in matrix format, where each column is an individual data point
--   `df` is the distance function as a symbol: `e2dist` `edist` `mdist` (see [section](##Distance Metrics))
+-   `df` is the distance function as a symbol: ``` `e2dist`edist`mdist ``` (see [section](##Distance Metrics))
 -   `minpts` is the minimum number of points required in a given neighborhood to define a cluster
 -   `eps` is the epsilon radius, the distance from each point within which points are defined as being in the same cluster
 
@@ -486,7 +486,7 @@ Syntax: `.ml.clust.hc.fit[data;df;lf]`
 Where
 
 -   `data` represents the points being analyzed in matrix format, where each column is an individual datapoint
--   `df` is the distance function as a symbol: ``` `e2dist`edist`mdist` ``` (see [section](##Distance Metrics))
+-   `df` is the distance function as a symbol: ``` `e2dist`edist`mdist ``` (see [section](##Distance Metrics))
 -   `lf` is the linkage function as a symbol: ``` `single`complete`average`centroid`ward ```
 
 returns a dictionary with data, input variables and a dendrogram table, describing the order in which clusters are joined, and the distance between the clusters as they are joined.

--- a/docs/ml/toolkit/clustering/algos.md
+++ b/docs/ml/toolkit/clustering/algos.md
@@ -52,11 +52,11 @@ Dendrogram Cutting Functionality
 
 The clustering library provides q implementations of a number of common clustering algorithms, with fit and predict functions provided for each. Update functions are also available for K-Means and DBSCAN.
 
-Hierarchical clustering methods (including CURE) produce dendrograms, which can then be _cut_ at a given count or distance to produce a clustering.
+In addition to the fit/predict functionality provided for all methods, for hierarchical clustering methods (including CURE) which produce dendrograms, functions to _cut_ the dendrogram at a given count or distance are also provided allowing a user to produce appropriate clusters.
 
 ## Affinity Propagation
 
-Affinity Propagation groups data based on the similarity between points and subsequently finds _exemplars_, which best represent the points in each cluster. The algorithm does not require the number of clusters, but determines the optimum solution by exchanging real-valued messages between points until a high-valued set of exemplars is produced.
+Affinity Propagation groups data based on the similarity between points and subsequently finds _exemplars_, which best represent the points in each cluster. The algorithm does not require the number of clusters be provided at run time, but determines the optimum solution by exchanging real-valued messages between points until a high-valued set of exemplars is produced.
 
 The algorithm uses a user-specified damping coefficient to reduce the availability and responsibility of messages passed between points, while a preference value is used to set the diagonal values of the similarity matrix. A more detailed explanation of the algorithm can be found [here](https://towardsdatascience.com/unsupervised-machine-learning-affinity-propagation-algorithm-explained-d1fef85f22c8).
 
@@ -64,7 +64,7 @@ The algorithm uses a user-specified damping coefficient to reduce the availabili
 
 _Fit AP algorithm_
 
-Syntax: `.ml.clust.ap.fit[data;df;dmp;diag;]`
+Syntax: `.ml.clust.ap.fit[data;df;dmp;diag;iter]`
 
 Where
 
@@ -81,13 +81,13 @@ q)show d:2 10#20?10.
 7.833686 4.099561 6.108817 4.976492  4.087545 4.49731  0.1392076 7.148779 1.9..
 6.203014 9.326316 2.747066 0.5752516 2.560658 2.310108 0.8724017 1.024432 8.6..
 
-q)// fit to AP algorithm
+// fit to AP algorithm
 q)show APfit:.ml.clust.ap.fit[d;`nege2dist;.3;med;(::)]
 data  | (7.833686 4.099561 6.108817 4.976492 4.087545 4.49731 0.1392076 7.148..
 inputs| `df`dmp`diag`iter!(`nege2dist;0.3;k){avg x(<x)@_.5*-1 0+#x,:()};`maxrun`maxmatch!200 50)
 clt   | 0 1 0 0 0 0 2 0 1 1
 
-q)// group indices into their calculated clusters
+// group indices into their calculated clusters
 q)group APfit`clt
 0| 0 2 3 4 5 7
 1| 1 8 9
@@ -102,75 +102,31 @@ Syntax: `.ml.clust.ap.predict[data;cfg]`
 
 Where
 
--   `data` represents the points being analyzed in matrix format, where each column is an individual data point
--   `cfg` represents a dictionary with data, input variables and the cluster each data point belongs to, returned from `.ml.clust.ap.fit`
+-   `data` represents the points being analyzed in matrix format, where each column is an individual data point.
+-   `cfg` represents a dictionary with data, input variables and the cluster each data point belongs to, returned from `.ml.clust.ap.fit`.
 
 returns predicted clusters of new data.
 
 ```q
-q)// training data
+// training data
 q)show trn:2 10#20?10.
 1.627662 6.884756 8.177547 7.520102 1.086824 9.598964 0.3668341 6.430982 6.70..
 4.12317  9.877844 3.867353 7.26781  4.046546 8.355065 6.42737   5.830262 1.42..
 
-q)// fit AP algorithm
+// fit AP algorithm
 q)show APfit:.ml.clust.ap.fit[trn;`nege2dist;.3;med;(::)]
 data  | (1.627662 6.884756 8.177547 7.520102 1.086824 9.598964 0.3668341 6.43..
 inputs| `df`dmp`diag`iter!(`nege2dist;0.3;k){avg x(<x)@_.5*-1 0+#x,:()};`maxrun`maxmatch!200 50)
 clt   | 0 1 2 1 0 1 0 1 2 1
 
-q)// testing data
+// testing data
 q)show tst:2 5#10?10.
 9.030751 7.750292 3.869818  6.324114 4.328535
 2.430836 3.917953 0.2451336 1.691043 3.941082
 
-q)// predicted clusters
+// predicted clusters
 q).ml.clust.ap.predict[tst;APfit]
 2 2 2 2 0
-```
-
-### `.ml.clust.ap.update`
-
-_Update AP model_
-
-Syntax: `.ml.clust.ap.update[data;cfg]`
-
-Where
-
--   `data` represents the points being analyzed in matrix format, where each column is an individual data point
--   `cfg` represents a dictionary with data, input variables and the cluster each data point belongs to, returned from `.ml.clust.ap.fit`
-
-returns updated config dictionary, with new data points added.
-
-```q
-q)// training data
-q)show trn:2 10#20?10.
-3.927524 5.170911 5.159796  4.066642 1.780839 3.017723 7.85033  5.347096 7.11..
-4.931835 5.785203 0.8388858 1.959907 3.75638  6.137452 5.294808 6.916099 2.29..
-
-q)// fit AP algorithm
-q)show APfit:.ml.clust.ap.fit[trn;`nege2dist;.3;med;(::)]
-data  | (3.927524 5.170911 5.159796 4.066642 1.780839 3.017723 7.85033 5.3470..
-inputs| `df`dmp`diag`iter!(`nege2dist;0.3;k){avg x(<x)@_.5*-1 0+#x,:()};`maxrun`maxmatch!200 50)
-clt   | 0 0 1 1 2 0 0 0 1 0
-
-q)// testing data
-q)show tst:2 5#10?10.
-4.707883 6.346716 9.672398 2.306385 9.49975
-4.39081  5.759051 5.919004 8.481567 3.89056
-
-q)// update model with new testing data points added
-q)show APupd:.ml.clust.ap.update[tst;APfit]
-data  | (3.927524 5.170911 5.159796 4.066642 1.780839 3.017723 7.85033 5.3470..
-inputs| `df`dmp`diag`iter!(`nege2dist;0.3;k){avg x(<x)@_.5*-1 0+#x,:()};`maxrun`maxmatch!200 50)
-clt   | 0 1 2 2 0 1 3 1 2 1 0 3 3 1 3
-
-q)// group indices into their calculated clusters
-q)group APupd`clt
-0| 0 4 10
-1| 1 5 7 9 13
-2| 2 3 8
-3| 6 11 12 14
 ```
 
 ## Clustering Using Representatives
@@ -185,25 +141,25 @@ Syntax: `.ml.clust.cure.fit[data;df;n;c]`
 
 Where
 
--   `data` represents the points being analyzed in matrix format, where each column is an individual data point
--   `df`  is the distance function as a symbol: `e2dist` `edist` `mdist` – see [Distance Metrics](#distance-metrics)
--   `n` is the number of representative points
--   `c` is the compression ratio
+-   `data` represents the points being analyzed in matrix format, where each column is an individual data point.
+-   `df`  is the distance function as a symbol: `e2dist` `edist` `mdist` – see [Distance Metrics](#distance-metrics).
+-   `n` is the number of representative points.
+-   `c` is the compression ratio.
 
-returns a dictionary with data, input variables and a dendrogram table, describing the order in which clusters are joined, and the distance between the clusters as they are joined.
+returns a dictionary with data, input variables and a dendrogram table. The dendrogram table describes the order in which clusters are joined, and the distance between the clusters as they are joined.
 
 ```q
 q)show d:2 10#20?20.
 7.83086  1.624709 18.73501 5.564243 4.784682 3.016266 3.134634  19.57    14.0..
 15.66737 8.199122 12.21763 9.952983 8.175089 8.994621 0.2784152 14.29756 3.89..
 
-q)// fit to CURE algorithm
+// fit to CURE algorithm
 q)show CUREfit:.ml.clust.cure.fit[d;`e2dist;2;0]
 data  | (7.83086 1.624709 18.73501 5.564243 4.784682 3.016266 3.134634 19.57 ..
 inputs| `df`n`c!(`e2dist;2;0)
 dgram | +`i1`i2`dist`n!(1 3 10 2 8 0 15 13 16i;5 4 11 7 9 12 6 14 17i;2.56924..
 
-q)// dendrogram with Euclidean-squared distances
+// dendrogram with Euclidean-squared distances
 q)CUREfit`dgram
 i1 i2 dist     n
 -----------------
@@ -222,7 +178,7 @@ data  | (7.83086 1.624709 18.73501 5.564243 4.784682 3.016266 3.134634 19.57 ..
 inputs| `df`n`c!(`mdist;5;0.5)
 dgram | +`i1`i2`dist`n!(1 3 10 2 8 12 0 13 16i;5 4 11 7 9 6 15 14 17i;2.18705..
 
-q)// dendrogram with Manhattan distances
+// dendrogram with Manhattan distances
 q)CUREfit`dgram
 i1 i2 dist     n
 -----------------
@@ -239,29 +195,29 @@ i1 i2 dist     n
 
 ### `.ml.clust.cure.cutdist`
 
-_Cut dendrogram into clusters based on a distance threshold_
+_Cut a dendrogram into clusters based on a threshold distance_
 
 Syntax: `.ml.clust.cure.cutdist[cfg;dist]`
 
 Where
 
 -   `cfg` is the output dictionary containing a dendrogram table produced by the CURE fit function
--   `dist` is the distance threshold applied when cutting the dendrogram into clusters
+-   `dist` is the threshold distance applied when cutting the dendrogram into clusters
 
-returns updated `cfg` with list indicating the cluster each data point belongs to.
+returns an updated `cfg` containing a new key ``` `clt ``` indicating the cluster to which each data point belongs.
 
 ```q
 q)show d:2 10#20?10.
 9.030751 7.750292 3.869818 6.324114 4.328535 2.430836  3.917953 0.2451336 1.6..
 7.263142 9.216436 1.809536 6.434637 2.907093 0.7347808 3.159526 3.410485  8.6..
 
-q)// fit CURE algorithm
+// fit CURE algorithm
 q)show cfg:.ml.clust.cure.fit[d;`mdist;2;.5]
 data  | (9.030751 7.750292 3.869818 6.324114 4.328535 2.430836 3.917953 0.245..
 inputs| `df`n`c!(`mdist;2;0.5)
 dgram | +`i1`i2`dist`n!(4 2 11 12 0 14 13 16 15i;6 10 5 9 1 3 7 8 17i;0.66301..
 
-q)// cut dendrogram using a distance threshold of 5.2
+// cut dendrogram using a distance threshold of 5.2
 q)show r:.ml.clust.hc.cutdist[cfg;5.2]
 data  | (9.030751 7.750292 3.869818 6.324114 4.328535 2.430836 3.917953 0.245..
 inputs| `df`n`c!(`mdist;2;0.5)
@@ -276,7 +232,7 @@ q)group r`clt
 
 ### `.ml.clust.cure.cutk`
 
-_Cut dendrogram into k clusters_
+_Cut a dendrogram into k clusters_
 
 Syntax: `.ml.clust.hc.cutk[cfg;k]`
 
@@ -285,20 +241,20 @@ Where
 -   `cfg` is the output dictionary containing a dendrogram table produced by the CURE fit function
 -   `k` is the number of clusters to be produced from cutting the dendrogram
 
-returns updated `cfg` with list indicating the cluster each data point belongs to.
+returns an updated `cfg` containing a new key ``` `clt ``` indicating the cluster to which each data point belongs.
 
 ```q
 q)show d:2 10#20?10.
 0.6165008 2.85799  6.684724 9.133033  1.485357 4.857547 7.123602 3.839461 3.4..
 5.497936  1.958467 5.615261 0.7043811 2.124007 7.77882  4.844727 6.827999 1.5..
 
-q)// fit CURE algorithm
+// fit CURE algorithm
 q)show cfg:.ml.clust.cure.fit[d;`e2dist;2;0.]
 data  | (0.6165008 2.85799 6.684724 9.133033 1.485357 4.857547 7.123602 3.839..
 inputs| `df`n`c!(`e2dist;2;0f)
 dgram | +`i1`i2`dist`n!(0 1 2 11 5 12 10 16 17i;9 8 6 4 7 14 13 15 3i;0.02746..
 
-q)// cut the dendrogram into 3 clusters
+// cut the dendrogram into 3 clusters
 q)show r:.ml.clust.cure.cutk[cfg;3]
 data  | (0.6165008 2.85799 6.684724 9.133033 1.485357 4.857547 7.123602 3.839..
 inputs| `df`n`c!(`e2dist;2;0f)
@@ -325,18 +281,18 @@ Where
 returns predicted clusters of new data.
 
 ```q
-q)// training data
+// training data
 q)show trn:2 10#20?10.
 7.263142  9.216436 1.809536 6.434637 2.907093 0.7347808 3.159526 3.410485 8.6..
 0.6165008 2.85799  6.684724 9.133033 1.485357 4.857547  7.123602 3.839461 3.4..
 
-q)// fit CURE algorithm
+// fit CURE algorithm
 q)show CUREfit:.ml.clust.cure.fit[trn;`e2dist;2;.5]
 data  | (7.263142 9.216436 1.809536 6.434637 2.907093 0.7347808 3.159526 3.41..
 inputs| `df`n`c!(`e2dist;2;0.5)
 dgram | +`i1`i2`dist`n!(1 2 0 11 4 13 12 16 17i;8 6 9 5 7 14 10 15 3i;0.65980..
 
-q)// dendrogram
+// dendrogram
 q)CUREfit`dgram
 i1 i2 dist      n
 ------------------
@@ -350,19 +306,19 @@ i1 i2 dist      n
 16 15 19.37815  9
 17 3  35.80449  10
 
-q)// cut dendrogram
+// cut dendrogram
 q)show clt:.ml.clust.cure.cutk[CUREfit;3]
 data  | (7.263142 9.216436 1.809536 6.434637 2.907093 0.7347808 3.159526 3.41..
 inputs| `df`n`c!(`e2dist;2;0.5)
 dgram | +`i1`i2`dist`n!(1 2 0 11 4 13 12 16 17i;8 6 9 5 7 14 10 15 3i;0.65980..
 clt   | 0 0 1 2 1 1 1 1 0 0
 
-q)// create testing data
+// create testing data
 q)show tst:2 5#10?10.
 5.497936 1.958467 5.615261 0.7043811 2.124007
 7.77882  4.844727 6.827999 1.53227   5.350923
 
-q)// predicted clusters
+// predicted clusters
 q).ml.clust.cure.predict[tst;clt]
 2 1 2 1 1
 ```
@@ -371,10 +327,10 @@ q).ml.clust.cure.predict[tst;clt]
 
 The Density-Based Spatial Clustering of Applications with Noise (DBSCAN) algorithm, groups points that are closely packed in areas of high density. Any points in low-density regions are seen as outliers.
 
-Unlike many clustering algorithms, which require the user to input the desired number of clusters, DBSCAN calculates how many clusters are in the dataset based two criteria
+Unlike many clustering algorithms, which require the user to input the desired number of clusters, DBSCAN calculates how many clusters are in the dataset based on two criteria.
 
--   The minimum number of points required within a neighborhood in order for a cluster to be defined
--   The epsilon radius: the distance from each point within which points will be defined as being part of the same cluster
+1. The minimum number of points required within a neighborhood in order for a cluster to be defined.
+2. The epsilon radius: The distance from each point within which points will be defined as being part of the same cluster.
 
 ### `.ml.clust.dbscan.fit`
 
@@ -389,29 +345,29 @@ Where
 -   `minpts` is the minimum number of points required in a given neighborhood to define a cluster
 -   `eps` is the epsilon radius, the distance from each point within which points are defined as being in the same cluster
 
-returns a dictionary with data, input variables, cluster table required for predict/update methods and the cluster each data point belongs to. Any outliers in the data will return a negative value as their cluster.
+returns a dictionary with data, input variables, cluster table required for predict/update methods and the cluster each data point belongs to. Any outliers in the data will return a value of `-1` as their cluster.
 
 ```q
 q)show d:2 10#20?5.
 3.852387 0.07970141 1.786519 0.1273692 3.440445 3.188777  0.1922818 4.486179 ..
 3.878809 0.3469163  2.050957 1.168774  3.562923 0.6961287 1.350938  3.178591 ..
 
-q)// fit DBSCAN algorithm
+// fit DBSCAN algorithm
 q)show DBSCANfit:.ml.clust.dbscan.fit[d;`e2dist;2;1]
 data  | (3.852387 0.07970141 1.786519 0.1273692 3.440445 3.188777 0.1922818 4..
 inputs| `df`minpts`eps!(`e2dist;2;1)
 clt   | 0 1 -1 1 0 -1 1 0 0 1
 t     | +`nbhood`cluster`corepoint!((4 7 8;3 9;`long$();1 6;0 8;`long$();,3;0..
 
-q)// clusters without outliers returns as -1
+// points not assigned to a cluster return as -1
 q)DBSCANfit`clt
 0 1 -1 1 0 -1 1 0 0 1
 
-q)// radius too larger - returns one cluster
+// radius too larger - returns one cluster
 q).ml.clust.dbscan.fit[d;`e2dist;3;7]`clt
 0 0 0 0 0 0 0 0 0 0
 
-q)// radius too small - clustering not possible, points returned as individual clusters
+// radius too small - clustering not possible, points returned as individual clusters
 q).ml.clust.dbscan.fit[d;`e2dist;3;.1]`clt
 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 ```
@@ -425,29 +381,29 @@ Syntax: `.ml.clust.dbscan.predict[data;cfg]`
 Where
 
 -   `data` represents the points being analyzed in matrix format, where each column is an individual data point
--   `cfg` represents a dictionary with data, input variables and the cluster each data point belongs to, returned from `.ml.clust.dbscan.fit`
+-   `cfg` represents a dictionary with data, input variables, the cluster each data point in the original fit belongs to and the cluster table containing neighbourhood and core point information, returned from `.ml.clust.dbscan.fit`
 
 returns predicted clusters of new data.
 
 ```q
-q)// training data
+// training data
 q)show trn:2 10#20?10.
 3.852387 0.07970141 1.786519 0.1273692 3.440445 3.188777  0.1922818 4.486179 ..
 3.878809 0.3469163  2.050957 1.168774  3.562923 0.6961287 1.350938  3.178591 ..
 
-q)// fit DBSCAN algorithm
+// fit DBSCAN algorithm
 q)show DBSCANfit:.ml.clust.dbscan.fit[trn;`e2dist;2;4]
 data  | (3.852387 0.07970141 1.786519 0.1273692 3.440445 3.188777 0.1922818 4..
 inputs| `df`minpts`eps!(`e2dist;2;4)
 clt   | 0 1 1 1 0 1 1 0 0 1
 t     | +`nbhood`cluster`corepoint!((4 7 8;3 6 9;3 5 6 9;1 2 6 9;0 7 8;,2;1 2..
 
-q)// testing data
+// testing data
 q)show tst:2 5#10?10.
 4.500925 5.383159 2.144614 1.956173 3.467262
 2.040159 2.416457 2.370978 1.55879  4.374481
 
-q)// predicted clusters
+// predicted clusters
 q).ml.clust.dbscan.predict[tst;DBSCANfit]
 0 0 1 1 0
 ```
@@ -461,35 +417,35 @@ Syntax: `.ml.clust.dbscan.update[data;cfg]`
 Where
 
 -   `data` represents the points being analyzed in matrix format, where each column is an individual data point
--   `cfg` represents a dictionary with data, input variables and the cluster each data point belongs to, returned from `.ml.clust.dbscan.fit`
+-   `cfg` represents a dictionary with data, input variables, the cluster each data point in the original fit belongs to and the cluster table containing neighbourhood and core point information, returned from `.ml.clust.dbscan.fit`
 
 returns updated config dictionary, with new data points added.
 
 ```q
-q)// training data
+// training data
 q)show trn:2 10#20?10.
 7.690142 8.680675 6.423079 8.06548  1.108819 2.213596 4.92768  2.404443 8.359..
 8.361305 9.83146  1.387587 9.356649 2.594134 2.647525 3.190391 3.975792 8.620..
 
-q)// fit DBSCAN algorithm
+// fit DBSCAN algorithm
 q)show DBSCANfit:.ml.clust.dbscan.fit[trn;`e2dist;2;5.5]
 data  | (7.690142 8.680675 6.423079 8.06548 1.108819 2.213596 4.92768 2.40444..
 inputs| `df`minpts`eps!(`e2dist;2;5.5)
 clt   | 0 0 1 0 2 2 1 2 0 1
 t     | +`nbhood`cluster`corepoint!((1 3 8;0 3 8;6 9;0 1 8;5 7;4 7;,2;4 5;0 1..
 
-q)// testing data
+// testing data
 q)show tst:2 5#10?10.
 4.500925 5.383159 2.144614 1.956173 3.467262
 2.040159 2.416457 2.370978 1.55879  4.374481
 
-q)// update model with new testing data points added
+// update model with new testing data points added
 q)show DBSCANupd:.ml.clust.dbscan.update[tst;DBSCANfit]
 data  | (7.690142 8.680675 6.423079 8.06548 1.108819 2.213596 4.92768 2.40444..
 inputs| `df`minpts`eps!(`e2dist;2;5.5)
 clt   | 0 0 1 0 2 2 1 2 0 1 0 -1 1 2 0
 
-q)// group indices into their calculated clusters
+// group indices into their calculated clusters
 q)group DBSCANupd`clt
 0 | 0 1 3 8 10 14
 1 | 2 6 9 12
@@ -519,7 +475,7 @@ plt[`:show][]
 ![dendro_plot](img/dendrogram_example.png)
 
 !!! warning "Ward linkage"
-    Ward linkage only works in conjunction with Euclidean squared distances (`e2dist`), while centroid linkage only works with Euclidean distances (`e2dist`, `edist`). If the user tries to input a different distance metric an error will result, as shown above.
+    Ward linkage only works in conjunction with Euclidean squared distances (`e2dist`), while centroid linkage only works with Euclidean distances (`e2dist`, `edist`). If the user tries to input a different distance metric an error will result, as shown below.
 
 ### `.ml.clust.hc.fit`
 
@@ -530,8 +486,8 @@ Syntax: `.ml.clust.hc.fit[data;df;lf]`
 Where
 
 -   `data` represents the points being analyzed in matrix format, where each column is an individual datapoint
--   `df` is the distance function as a symbol: `e2dist` `edist` `mdist` (see [section](##Distance Metrics))
--   `lf` is the linkage function as a symbol: `single`  `complete` `average` `centroid` `ward`
+-   `df` is the distance function as a symbol: ``` `e2dist`edist`mdist` ``` (see [section](##Distance Metrics))
+-   `lf` is the linkage function as a symbol: ``` `single`complete`average`centroid`ward ```
 
 returns a dictionary with data, input variables and a dendrogram table, describing the order in which clusters are joined, and the distance between the clusters as they are joined.
 
@@ -546,7 +502,7 @@ data  | (3.554867 1.116953 4.284428 4.238193 1.795281 1.831922 4.299089 4.000..
 inputs| `df`lf!`e2dist`single
 dgram | +`i1`i2`dist`n!(6 0 11 12 13 14 15 16 17i;8 10 3 9 2 4 5 7 1i;0.15547..
 
-q)// dendrogram for Euclidean-squared distances
+// dendrogram for Euclidean-squared distances
 q)HCfit`dgram
 i1 i2 dist      n
 ------------------
@@ -560,13 +516,13 @@ i1 i2 dist      n
 16 7  2.400575  9
 17 1  2.598447  10
 
-q)// fit complete hierarchical algorithm
+// fit complete hierarchical algorithm
 q)show HCfit:.ml.clust.hc.fit[d;`mdist;`complete]
 data  | (3.554867 1.116953 4.284428 4.238193 1.795281 1.831922 4.299089 4.000..
 inputs| `df`lf!`mdist`complete
 dgram | +`i1`i2`dist`n!(6 0 10 4 2 11 1 15 17i;8 3 9 5 7 12 13 14 16i;0.55370..
 
-q)// dendrogram for Manhattan distances
+// dendrogram for Manhattan distances
 q)HCfit`dgram
 i1 i2 dist      n
 ------------------
@@ -580,21 +536,21 @@ i1 i2 dist      n
 15 14 4.904601  7
 17 16 6.270349  10
 
-q)// fit ward hierarchical algorithm
+// fit ward hierarchical algorithm
 q).ml.clust.hc.fit[d;`mdist;`ward]
 'ward must be used with e2dist
 ```
 
 ### `.ml.clust.hc.cutdist`
 
-_Cut dendrogram into clusters based on a distance threshold_
+_Cut a dendrogram into clusters based on a threshold distance_
 
 Syntax: `.ml.clust.hc.cutdist[cfg;dist]`
 
 Where
 
 -   `cfg` is the output dictionary containing a dendrogram table produced by the hierarchical clustering functions
--   `dist` is the distance threshold applied when cutting the dendrogram into clusters
+-   `dist` is the threshold distance applied when cutting the dendrogram into clusters
 
 returns updated `cfg` with list indicating the cluster each data point belongs to.
 
@@ -603,14 +559,14 @@ q)show d:2 10#20?10.
 4.707883 6.346716  9.672398 2.306385 9.49975  4.39081  5.759051 5.919004 8.48..
 3.91543  0.8123546 9.367503 2.782122 2.392341 1.508133 1.567317 9.785    7.04..
 
-q)// fit complete hierarchical algorithm
-q)show cfg:.ml.clust.hc.fit[d;`mdist;`complete]
+// fit complete hierarchical algorithm
+q)show HCfit:.ml.clust.hc.fit[d;`mdist;`complete]
 data  | (4.707883 6.346716 9.672398 2.306385 9.49975 4.39081 5.759051 5.91900..
 inputs| `df`lf!`mdist`complete
 dgram | +`i1`i2`dist`n!(1 7 10 2 0 12 13 14 17i;6 9 5 8 3 4 11 15 16i;1.34262..
 
-q)// cut dendrogram using a distance threshold of 6.5
-q)show r:.ml.clust.hc.cutdist[cfg;6.5]
+// cut dendrogram using a distance threshold of 6.5
+q)show r:.ml.clust.hc.cutdist[HCfit;6.5]
 data  | (4.707883 6.346716 9.672398 2.306385 9.49975 4.39081 5.759051 5.91900..
 inputs| `df`lf!`mdist`complete
 dgram | +`i1`i2`dist`n!(1 7 10 2 0 12 13 14 17i;6 9 5 8 3 4 11 15 16i;1.34262..
@@ -625,13 +581,13 @@ q)group r`clt
 
 ### `.ml.clust.hc.cutk`
 
-_Cut dendrogram into k clusters_
+_Cut a dendrogram into k clusters_
 
 Syntax: `.ml.clust.hc.cutk[cfg;k]`
 
 Where
 
--   `cfg` is the output dictionary containing a dendrogram table produced by the hierarchical clustering functions
+-   `cfg` is the output dictionary containing a dendrogram table produced by the hierarchical clustering fit function
 -   `k` is the number of clusters to be produced from cutting the dendrogram
 
 returns updated `cfg` with list indicating the cluster each data point belongs to.
@@ -641,14 +597,14 @@ q)show d:2 10#20?10.
 7.833686 4.099561 6.108817 4.976492  4.087545 4.49731  0.1392076 7.148779 1.9..
 6.203014 9.326316 2.747066 0.5752516 2.560658 2.310108 0.8724017 1.024432 8.6..
 
-q)// fit single hierarchical algorithm
-q)show cfg:.ml.clust.hc.fit[d;`e2dist;`single]
+// fit single hierarchical algorithm
+q)show HCfit:.ml.clust.hc.fit[d;`e2dist;`single]
 data  | (7.833686 4.099561 6.108817 4.976492 4.087545 4.49731 0.1392076 7.148..
 inputs| `df`lf!`e2dist`single
 dgram | +`i1`i2`dist`n!(4 2 8 11 13 1 0 16 17i;5 10 9 3 7 12 14 6 15i;0.23068..
 
-q)// cut the dendrogram into 3 clusters
-q)show r:.ml.clust.hc.cutk[cfg;3]
+// cut the dendrogram into 3 clusters
+q)show r:.ml.clust.hc.cutk[HCfit;3]
 data  | (7.833686 4.099561 6.108817 4.976492 4.087545 4.49731 0.1392076 7.148..
 inputs| `df`lf!`e2dist`single
 dgram | +`i1`i2`dist`n!(4 2 8 11 13 1 0 16 17i;5 10 9 3 7 12 14 6 15i;0.23068..
@@ -674,18 +630,18 @@ Where
 returns predicted clusters of new data.
 
 ```q
-q)// training data
+// training data
 q)show trn:2 10#20?10.
 1.886663 1.096443 1.805561 5.187677 8.834092 9.879205 7.294094 7.693545 4.430..
 7.367721 6.803906 7.314941 8.778704 3.388493 9.480718 9.873482 3.300002 8.305..
 
-q)// fit single hierarchical algorithm
+// fit single hierarchical algorithm
 q)show HCfit:.ml.clust.hc.fit[d;`e2dist;`single]
 data  | (3.554867 1.116953 4.284428 4.238193 1.795281 1.831922 4.299089 4.000..
 inputs| `df`lf!`e2dist`single
 dgram | +`i1`i2`dist`n!(6 0 11 12 13 14 15 16 17i;8 10 3 9 2 4 5 7 1i;0.15547..
 
-q)// dendrogram
+// dendrogram
 q)HCfit`dgram
 i1 i2 dist      n
 ------------------
@@ -699,19 +655,19 @@ i1 i2 dist      n
 16 7  2.400575  9
 17 1  2.598447  10
 
-q)// cut dendrogram
+// cut dendrogram
 q)show clt:.ml.clust.hc.cutk[HCfit;3]
 data  | (3.554867 1.116953 4.284428 4.238193 1.795281 1.831922 4.299089 4.000..
 inputs| `df`lf!`e2dist`single
 dgram | +`i1`i2`dist`n!(6 0 11 12 13 14 15 16 17i;8 10 3 9 2 4 5 7 1i;0.15547..
 clt   | 0 2 0 0 0 0 0 1 0 0
 
-q)// create testing data
+// create testing data
 q)show tst:2 5#10?10.
 7.010229 2.362643 3.893913 4.566197 9.771774
 3.607297 9.265934 3.07924  1.045391 8.376952
 
-q)// predicted clusters
+// predicted clusters
 q).ml.clust.hc.predict[tst;clt]
 0 0 0 2 0
 ```
@@ -720,7 +676,7 @@ q).ml.clust.hc.predict[tst;clt]
 
 K-means clustering begins by selecting k data points as cluster centers and assigning data to the cluster with the nearest center.
 
-The algorithm follows an iterative refinement process which runs a specified number of times, updating the cluster centers and assigned points with each iteration.
+The algorithm follows an iterative refinement process which runs a specified number of times, updating the cluster centers and assigned points to a cluster at each iteration based on the nearest cluster center.
 
 The distance metrics that can be used with the K-Means algorithm are the Euclidean distances (`e2dist`,`edist`). The use of any other distance metric will result in an error.
 
@@ -733,7 +689,7 @@ Syntax: `.ml.clust.kmeans.fit[data;df;k;iter;kpp]`
 Where
 
 -   `data` represents the points being analyzed in matrix format, where each column is an individual data point
--   `df` is the distance function: `e2dist` `edist` (see [section](##Distance Metrics))
+-   `df` is the distance function: ``` `e2dist`edist ``` (see [section](##Distance Metrics))
 -   `k` is the number of clusters
 -   `iter` is the number of iterations to be completed
 -   `kpp` is a boolean flag indicating the initializaton type: random (`0b`) or using [k-means++](https://en.wikipedia.org/wiki/K-means%2B%2B) (`1b`)
@@ -745,7 +701,7 @@ q)show d:2 10#20?5.
 3.885652 0.4113437 2.566009 2.473914 4.332783   3.207488  4.541356 4.898047 1..
 4.795588 2.060933  3.165205 2.876346 0.04505872 0.7240285 3.853066 1.848057 0..
 
-q)// Initialize using the k++ algorithm
+// initialize using the k++ algorithm
 q)show kmeansfit:.ml.clust.kmeans.fit[d;`e2dist;3;10;1b]
 reppts| (3.058613 3.86148;0.9750445 1.324305;4.146106 0.8723815)
 clt   | 0 1 0 0 2 2 0 2 1 0
@@ -754,7 +710,7 @@ inputs| `df`k`iter`kpp!(`e2dist;3;10;1b)
 q)kmeansfit`clt
 0 1 0 0 2 2 0 2 1 0
 
-q)// Initialize using random centers
+// initialize using random centers
 q)show kmeansfit:.ml.clust.kmeans.fit[d;`e2dist;3;10;0b]
 reppts| (3.058613 3.86148;0.9750445 1.324305;4.146106 0.8723815)
 clt   | 0 1 0 0 2 2 0 2 1 0
@@ -781,24 +737,24 @@ Where
 returns predicted clusters of new data.
 
 ```q
-q)// training data
+// training data
 q)show trn:2 10#20?10.
 5.794801 9.029713 2.011578  0.6832366 5.989167 0.4881728 9.006991 8.505909 8...
 8.187707 6.506965 0.3492196 0.3283839 9.675763 3.01404   6.919292 9.471555 3...
 
-q)// fit kmeans algorithm
+// fit kmeans algorithm
 q)show kmeansfit:.ml.clust.kmeans.fit[trn;`e2dist;3;10;1b]
 reppts| (7.753766 7.360869;1.060996 1.230548;0.9982673 9.614594)
 clt   | 0 0 1 1 0 1 0 0 0 2
 data  | (5.794801 9.029713 2.011578 0.6832366 5.989167 0.4881728 9.006991 8.5..
 inputs| `df`k`iter`kpp!(`e2dist;3;10;1b)
 
-q)// testing data
+// testing data
 q)show tst:2 5#10?10.
 8.649262 3.114364 8.132478 1.291938 1.477547
 2.74227  5.635053 8.83823  2.439194 6.718125
 
-q)// predicted clusters
+// predicted clusters
 q).ml.clust.kmeans.predict[tst;kmeansfit]
 0 2 0 1 2
 ```
@@ -817,31 +773,31 @@ Where
 returns updated config dictionary, with new data points added.
 
 ```q
-q)// training data
+// training data
 q)show trn:2 10#20?10.
 8.639591 8.439807 5.426371 0.7757332 6.374637 9.761246 5.396816 7.162858 3.88..
 8.725027 6.568734 9.625156 3.714973  1.744659 5.897202 9.550901 6.158515 7.02..
 
-q)// fit kmeans algorithm
+// fit kmeans algorithm
 q)show kmeansfit:.ml.clust.kmeans.fit[trn;`e2dist;3;15;0b]
 reppts| (7.600187 5.440753;4.903161 8.733536;0.7757332 3.714973)
 clt   | 0 0 1 2 0 0 1 0 1 0
 data  | (8.639591 8.439807 5.426371 0.7757332 6.374637 9.761246 5.396816 7.16..
 inputs| `df`k`iter`kpp!(`e2dist;3;15;0b)
 
-q)// testing data
+// testing data
 q)show tst:2 5#10?10.
 2.065625 5.229178 3.338806 4.14621  9.725813
 5.422726 6.116582 3.414991 9.516746 1.169475
 
-q)// update model with new testing data points added
+// update model with new testing data points added
 q)show kmeansupd:.ml.clust.kmeans.update[tst;kmeansfit]
 reppts| (7.569514 4.991322;4.713923 8.929338;2.060055 4.18423)
 clt   | 0 0 1 2 0 0 1 0 1 0 2 0 2 1 0
 data  | (8.639591 8.439807 5.426371 0.7757332 6.374637 9.761246 5.396816 7.16..
 inputs| `df`k`iter`kpp!(`e2dist;3;15;0b)
 
-q)// group indices into their calculated clusters
+// group indices into their calculated clusters
 q)group kmeansupd`clt
 0| 0 1 4 5 7 9 11 14
 1| 2 6 8 13

--- a/docs/ml/toolkit/clustering/algos.md
+++ b/docs/ml/toolkit/clustering/algos.md
@@ -102,8 +102,8 @@ Syntax: `.ml.clust.ap.predict[data;cfg]`
 
 Where
 
--   `data` represents the points being analyzed in matrix format, where each column is an individual data point.
--   `cfg` represents a dictionary with data, input variables and the cluster each data point belongs to, returned from `.ml.clust.ap.fit`.
+-   `data` represents the points being analyzed in matrix format, where each column is an individual data point
+-   `cfg` represents a dictionary with data, input variables and the cluster each data point belongs to, returned from `.ml.clust.ap.fit`
 
 returns predicted clusters of new data.
 

--- a/docs/ml/toolkit/graph/graph.md
+++ b/docs/ml/toolkit/graph/graph.md
@@ -13,7 +13,7 @@ As outlined [here](index.md) the graph structure described below follows the bas
 
 ## Structure
 
-Prior to the description of the functionality which allows a user can generate, update and remove components of a graph, a number notes on the technical aspects on the structure of these components must be outlined 
+Prior to the description of the functionality which allows a user to generate, update and remove components of a graph, a number of notes on the technical aspects on the structure of these components must be outlined 
 
 ### Functional node
 
@@ -34,7 +34,7 @@ The following image shows a graphical representation of such a node followed by 
 ```q
 // Node taking one input of float type and outputting one dictionary
 q)nodeInputs:"f"
-q)nodeOutputs:"!"
+q)nodeOutputs:"f"
 q)nodeFunction:{x wsum x}
 q)node:`inputs`outputs`function!(nodeInputs;nodeOutputs;nodeFunction)
 
@@ -51,7 +51,7 @@ Configuration nodes in this library are a subset of the functional nodes describ
 
 ### Edges
 
-An edge is a connection between the output of one functional or configuration node and the input of another node. In order to ensure that a graph is valid all input nodes must be connected to the output of another node within the graph, output nodes do not need to be connected to anything for a graph to be valid, in this case the return of an executed graph will store the output data for later use. A user must ensure that the type allocated to the input coincides with the type allocated to the output.
+An edge is a connection between the output of one functional or configuration node and the input of another node. In order to ensure that a graph is valid all input nodes must be connected to the output from another node within the graph. Output nodes do not need to be connected to anything for a graph to be valid, in this case the return of an executed graph will store the output data for later use. A user must ensure that the type allocated to the input coincides with the type allocated to the output to which it is connected.
 
 ## Functionality
 
@@ -177,9 +177,9 @@ Syntax: `.ml.connectEdge[graph;srcNode;srcName;destNode;destName]`
 Where
 
 * `graph` is a graph originally generated using `.ml.createGraph`
-* `srcNode` is a symbol denoting the name of a node in the graph which contains a relevant output.
+* `srcNode` is a symbol denoting the name of a node in the graph which contains the relevant output.
 * `srcName` is a symbol denoting the name of the output to be connected to an associated input node.
-* `destNode` is a symbol denoting the name of a node in the graph which contains a relevant input to be connected to.
+* `destNode` is a symbol denoting the name of a node in the graph which contains the relevant input to be connected to.
 * `destName` is a symbol denoting the name of the input which is connected to the output defined by `srcNode` and `srcName`.
 
 returns the graph with the relevant connection made between the inputs and outputs of two nodes
@@ -211,7 +211,7 @@ _Generate an empty graph_
 
 Syntax: `.ml.createGraph[]`
 
-returns a dictionary containing the structure required for the generation of a connected graph including information on the nodes present within the graph and how nodes within the graph are interconnected.
+returns a dictionary containing the structure required for the generation of a connected. This includes a key for information on the nodes present within the graph and edges outlining how the nodes within the graph are connected.
 
 ```q
 // Generate an empty graph
@@ -250,8 +250,10 @@ nodeId       |    function                                                   ..
 -------------| --------------------------------------------------------------..
              | :: ::                                                         ..
 configuration| :: @[;`xdata`ydata!(+`x`x1!(0.06165008 0.285799 0.6684724 0.91..
+
 // Delete the configuration node
 q)graph:.ml.delCfg[graph;`configuration]
+
 // Display the graph nodes 
 q)show graph.nodes
 nodeId|    function inputs outputs
@@ -279,8 +281,10 @@ nodeId |    function inputs         outputs
 -------| -------------------------------------------
        | :: ::       ::             ::              
 newNode| :: {x}      (,`input)!,"!" (,`srcName)!,"!"
+
 // Delete the configuration node
 q)graph:.ml.delNode[graph;`newNode]
+
 // Display the graph nodes 
 q)show graph.nodes
 nodeId|    function inputs outputs
@@ -298,9 +302,9 @@ Where
 
 * `graph` is a graph originally generated using `.ml.createGraph`.
 * `destNode` is the name as a symbol of the node containing the edge to be deleted.
-* `destName` is the name as a symbol of the edge associated with a specific input to be deleted.
+* `destName` is the name as a symbol of the edge associated with a specific input to be disconnected.
 
-returns the graph with the edge connected to the destination input deleted from the graph
+returns the graph with the edge connected to the destination input removed from the graph
 
 ```q
 // Display the graph prior to disconnection of an edge
@@ -310,8 +314,10 @@ dstNode  dstName | srcNode srcName valid
                  |                 0    
 srcNode  input   |                 0    
 destNode destName| srcNode srcName 1    
+
 // Disconnect an edge
 q)graph:.ml.disconnectEdge[graph;`destNode;`destName]
+
 // Display the graph edges post disconnection
 q)graph.edges
 dstNode  dstName | srcNode srcName valid
@@ -342,6 +348,7 @@ nodeId       |    function                                                inp..
 -------------| --------------------------------------------------------------..
              | :: ::                                                      :: ..
 configuration| :: ![,`output]@[enlist]@[;`xdata`ydata!(,0.3138309;`test)] (`s..
+
 // Update the configuration node content
 q)graph:.ml.updCfg[graph;`configuration;enlist[`xdata]!enlist 2?1f]
 q)graph.nodes
@@ -376,11 +383,13 @@ nodeId  |    function                inputs            outputs
         | :: ::                      ::                ::
 srcNode | :: {x}                     (,`input)!,"!"    (,`srcName)!,"!"
 destNode| :: ![,`output]@[enlist]{x} (,`destName)!,"!" (,`output)!,"F" 
+
 // Generate node content to overwrite the function for srcNode
 q)updSrcInput:"!"
 q)updSrcOutput:enlist[`srcName]!enlist "!"
 q)updSrcFunction:{x+1}
 q)updSrc:`inputs`outputs`function!(updSrcInput;updSrcOutput;updSrcFunction)
+
 // Overwrite the functional node
 q)graph:.ml.updNode[graph;`srcNode;updSrc]
 q)show graph.nodes


### PR DESCRIPTION
* Removal of update function definition for `ap` as this is no longer valid for the most up to date code base
* Removal of `q)` prefix for commenting of examples in line with the rest of the toolkit and automl
* Minor updates to wording 'threshold distance' rather than 'distance threshold' and some additional explanations
* Minor changes to the graphing documentation