### PR TITLE
review of pytorch docs addition

### DIFF
--- a/docs/ml/automl/faq.md
+++ b/docs/ml/automl/faq.md
@@ -40,7 +40,7 @@ Within the current version of this framework it is possible for a user to add Sk
 
 The addition of Sklearn models can be completed through the modification of a number of files within the folder `code/models`. The steps to do so are as follows.
 
-1.  Open the file relevant to the problem type being solved, namely classification/regression i.e. `classmodels.txt`/`regmodels.txt` respectively.
+1.  Open the file relevant to the problem type being solved, namely classification/regression i.e. `classmodels.txt`/`regmodels.txt` respectively from `code/models/models/`.
 
 2.  Add a row to the defined tabular flat file using the same format as shown below. This is a sample of a number of rows from the regression file (table header added for convenience)
 
@@ -69,7 +69,7 @@ The addition of Sklearn models can be completed through the modification of a nu
     BayesianRidge             | sklearn   ;  linear_model  ;    ::     ; reg
     </code></pre>
 
-3.  If a grid search is to be performed on the model, a user must add the model associated hyperparameters over which to perform this to the file `code/models/hyperparams.txt`, if not then the model name must be added to `.automl.i.excludelist` within `code/utils.q`. The following is an example of the hyperparameters which could be added for the Bayesian ridge regressor
+3.  If a grid search is to be performed on the model, a user must add the model associated hyperparameters over which to perform this to the file `code/models/hyperparameters/grid_hyperparameters.txt`, if not then the model name must be added to `.automl.i.excludelist` within `code/utils.q`. The following is an example of the hyperparameters which could be added for the Bayesian ridge regressor
 
     <pre><code class="language-q">BayesianRidge  |n_iter=100 200 300;tol=0.001 0.005 0.01</code></pre>
 
@@ -78,11 +78,10 @@ The addition of Sklearn models can be completed through the modification of a nu
 
 The addition of custom keras models is slightly more involved than that performed for scikit-learn models. The following steps show in their entirety the steps followed to add a custom regression model named `customreg` to the workflow.
 
-1.  Open the file `code/models/kerasmdls.q`
+1.  Open the file `code/models/lib_support/keras.q`
 
 2.  Follow the naming convention `[model-name]{mdl/fit/predict}` to create functions which define the model to be used, fit the model to the training data and predict the value of the target. Ensure the functions are defined in the root of the `.automl` namespace (this is already handled if within the `kerasmdls.q` file)
-
-    <pre><code class="language-q">$vi kerasmdls.q
+    <pre><code class="language-q">$vi keras.q
     \d .automl
     // Custom regression model
     /* d = mixed list containing ((xtrn;ytrn);(ytrn;ytst))
@@ -111,9 +110,8 @@ The addition of custom keras models is slightly more involved than that performe
     customregpredict:{[d;m]raze m[`:predict][npa d[1]0]`}
     </code></pre>
 
-    To ensure the behavior of the system is consistent with the framework, it is vital to follow the above instructions, particularly ensuring that models take as arguments the defined parameters and return an appropriate result, in particular at the model-definition phase, where explicit return of the model is required. Seeding of these models is not guaranteed unless a user has defined calls to functions such as `numpy.random.seed` to ensure that this is the case.
-
-    For the fitting and prediction of Keras models through embedPy, it is important that the feature data is a NumPy array. Omission of this conversion can cause issues. As seen above within `kerasmdls.q` this is done through application of `` `npa:.p.import[`numpy]`:array`` to the data.
+    * To ensure the behavior of the system is consistent with the framework, it is vital to follow the above instructions, particularly ensuring that models take as arguments the defined parameters and return an appropriate result, in particular at the model-definition phase, where explicit return of the model is required. Seeding of these models is not guaranteed unless a user has defined calls to functions such as `numpy.random.seed` to ensure that this is the case.
+    * For the fitting and prediction of Keras models through embedPy, it is important that the feature data is a NumPy array. Omission of this conversion can cause issues. As seen above within `kerasmdls.q` this is done through application of `` `npa:.p.import[`numpy]`:array`` to the data.
 
 
 3.  Update the list `.automl.i.keraslist` defined at the top of the `code/models/keramdls.q` file. The name of the model here must coincide with the naming convention to be used for displays to console and that defined in the next step as the `display-name`. At present grid search procedures are _not_ completed on Keras models.
@@ -123,11 +121,12 @@ The addition of custom keras models is slightly more involved than that performe
 
 4.  Go to `code/models/models/` and open `regmodels.txt` or `classmodels.txt` depending on use case. Add a row associated with the new model.
 
-    <pre><code class="language-txt">display-name    | model-type ; model-name ; seeded? ; problem-type
-    ----------------|------------;------------;---------;-------------
-    regkeras        | keras      ; reg        ; seed    ; reg
-    customregkeras  | keras      ; customreg  ; seed    ; reg
-    </code></pre>
+	<pre><code class="language-txt">display-name    | model-type ; model-name ; seeded? ; problem-type
+	----------------|------------;------------;---------;-------------
+	regkeras        | keras      ; reg        ; seed    ; reg
+	customregkeras  | keras      ; customreg  ; seed    ; reg
+	</code></pre>
+
 
     `display-name` is used for display and saving purposes. This is the name that should be added to the `.automl.i.keraslist` in order to be excluded from grid-search.
 
@@ -135,16 +134,30 @@ The addition of custom keras models is slightly more involved than that performe
     
 ### Pytorch Models
 
-Similarly to the keras models described above, the addition of pytorch is also more involved than that of the scikit-learn models. The following steps show in their entirety the steps followed to add a custom classification model named `Pytorch` to the workflow.
+The procedure which must be followed to add a custom pytorch model to automl follows closely that outlined for the addition of keras models above. The following steps show in their entirety the steps followed to add a custom classification model named `Pytorch` to the workflow.
 
-1.  Similarly to keras above, go to `code/models/models/` and open `regmodels.txt` or `classmodels.txt` depending on the use case. Following the `display-name | model-type ; model-name ; seeded? ; problem-type` structure, add your pytorch model. In this classification example we would add the following to `classmodels.txt`:
+1. Open the file to `classmodels.txt`/`regmodels.txt` in the folder `code/models/models/` depending on the problem type being tackled i.e. classification/regression respectively. In this example the model being added is a multi-class classification model.
 
-    <pre><code class="language-txt">Pytorch | pytorch ; torch ; seed ; torch
-    </code></pre>
+2. Add a row to the definition in the flat file using the schema defined below as a guide
 
-2.  Within the folder `code/models/lib_support/` there are two files associated with pytorch models - **torch.q** and **torch.p**. `torch.p` contains Python code required to define appropriate models and the code to run the model training iteratively, as shown in the below example:
+	<pre><code class="language-txt">display-name    | model-type ; model-name ; seeded? ; problem-type
+	----------------|------------;------------;---------;-------------
+	multikeras      | keras      ; multi      ; seed    ; multi
+	Pytorch         | torch      ; classtorch ; seed    ; multi
+	</code></pre>
+	
+	**Note:**
+	
+	* In the schema above, `classtorch`, in the 'model-name' column defines the prefix defining the `[model-name]{mdl/fit/predict}` functions which are retrieved from **pytorch.q**.
+	* The 'display-name' column is used for display and model saving purposes. This is also the name that should be added to the `.automl.i.torchlist` as outlined in step 3 below. This list ensures that the pytorch models are excluded from grid-search, functionality which is currently not supported.
+
+3.  Within the folder `code/models/lib_support/` there are two files associated with pytorch models - **torch.q** and **torch.p**. These files should contain the following information
+	* `torch.p` = Any Python code required to define the appropriate pytorch models.
+	* `torch.q` = The q functions which define the model, fit and predict functionality for any custom pytorch models. In addition to this the file contains a modifiable list `.automl.i.torchlist` which should be modified to include the `display-name` of the custom function as outlined in 2 above.
+
 
 ```python
+$vi torch.p
 class classifier(nn.Module):
 
     def __init__(self,input_dim, hidden_dim, dropout = 0.4):
@@ -178,12 +191,11 @@ def runmodel(model,optimizer,criterion,dataloader,n_epoch):
     return model
 ```
 
-`torch.q` contains q code which allows pytorch models to be run within the model pipeline. An example is shown below.
+`torch.q` contains q code which appropriately wraps a pytorch models such that it can be run within the model pipeline. The following wraps the pytorch functionality defined above into appropriately named q `model`, `fit` and `predict` functions.
 
 ```q
 \d .automl
 
-// import pytorch as torch
 npa    :.p.import[`numpy]`:array
 torch  :.p.import`torch
 optim  :.p.import`torch.optim
@@ -191,17 +203,17 @@ dloader:.p.import[`torch.utils.data]`:DataLoader
 .p.set[`nn;nn:.p.import`torch.nn]
 .p.set[`F;.p.import`torch.nn.functional]
 
-torchmdl:{[d;s;mtype]
+classtorchmdl:{[d;s;mtype]
   classifier:.p.get`classifier;
   classifier[count first d[0]0;200]
   }
 
-torchpredict:{[d;m]
+classtorchpredict:{[d;m]
   d_x:torch[`:from_numpy][npa d[1]0][`:float][];
   {(.p.wrap x)[`:detach][][`:numpy][][`:squeeze][]`}last torch[`:max][m d_x;1]`
   }
 
-torchfit:{[d;m]
+classtorchfit:{[d;m]
   optimizer:optim[`:Adam][m[`:parameters][];pykwargs enlist[`lr]!enlist .9];
   criterion:nn[`:BCEWithLogitsLoss][];
   data_x:torch[`:from_numpy][npa d[0]0][`:float][];

--- a/docs/ml/automl/faq.md
+++ b/docs/ml/automl/faq.md
@@ -132,9 +132,9 @@ The addition of custom keras models is slightly more involved than that performe
 
     `model-name` should observe the naming convention used in step 1 for `[model-name]{fit/...}`.
     
-### Pytorch Models
+### PyTorch Models
 
-The procedure which must be followed to add a custom pytorch model to automl follows closely that outlined for the addition of keras models above. The following steps show in their entirety the steps followed to add a custom classification model named `Pytorch` to the workflow.
+The procedure which must be followed to add a custom PyTorch model to automl follows closely that outlined for the addition of keras models above. The following steps show in their entirety the steps followed to add a custom classification model named `Pytorch` to the workflow.
 
 1. Open the file to `classmodels.txt`/`regmodels.txt` in the folder `code/models/models/` depending on the problem type being tackled i.e. classification/regression respectively. In this example the model being added is a multi-class classification model.
 
@@ -149,11 +149,11 @@ The procedure which must be followed to add a custom pytorch model to automl fol
 	**Note:**
 	
 	* In the schema above, `classtorch`, in the 'model-name' column defines the prefix defining the `[model-name]{mdl/fit/predict}` functions which are retrieved from **pytorch.q**.
-	* The 'display-name' column is used for display and model saving purposes. This is also the name that should be added to the `.automl.i.torchlist` as outlined in step 3 below. This list ensures that the pytorch models are excluded from grid-search, functionality which is currently not supported.
+	* The 'display-name' column is used for display and model saving purposes. This is also the name that should be added to the `.automl.i.torchlist` as outlined in step 3 below. This list ensures that the PyTorch models are excluded from grid-search, functionality which is currently not supported.
 
-3.  Within the folder `code/models/lib_support/` there are two files associated with pytorch models - **torch.q** and **torch.p**. These files should contain the following information
-	* `torch.p` = Any Python code required to define the appropriate pytorch models.
-	* `torch.q` = The q functions which define the model, fit and predict functionality for any custom pytorch models. In addition to this the file contains a modifiable list `.automl.i.torchlist` which should be modified to include the `display-name` of the custom function as outlined in 2 above.
+3.  Within the folder `code/models/lib_support/` there are two files associated with PyTorch models - **torch.q** and **torch.p**. These files should contain the following information
+	* `torch.p` = Any Python code required to define the appropriate PyTorch models.
+	* `torch.q` = The q functions which define the model, fit and predict functionality for any custom PyTorch models. In addition to this the file contains a modifiable list `.automl.i.torchlist` which should be modified to include the `display-name` of the custom function as outlined in 2 above.
 
 
 ```python
@@ -191,9 +191,10 @@ def runmodel(model,optimizer,criterion,dataloader,n_epoch):
     return model
 ```
 
-`torch.q` contains q code which appropriately wraps a pytorch models such that it can be run within the model pipeline. The following wraps the pytorch functionality defined above into appropriately named q `model`, `fit` and `predict` functions.
+`torch.q` defined below contains q code which appropriately wraps a PyTorch model such that it can be run within the model pipeline. The following wraps the PyTorch functionality defined above into appropriately named q `model`, `fit` and `predict` functions.
 
 ```q
+$vi torch.q
 \d .automl
 
 npa    :.p.import[`numpy]`:array


### PR DESCRIPTION
* Formatting changes to move pytorch definitions in line with keras model addition examples
* Folder naming changes to keras section
* Change of example display name `torch` to `classtorch` to be slightly clearer what the distinction is between sections
